### PR TITLE
Update home handling, fix tests for Windows

### DIFF
--- a/lib/dbi/dbrc.rb
+++ b/lib/dbi/dbrc.rb
@@ -4,7 +4,6 @@ if File::ALT_SEPARATOR
   require 'win32/dir'
   require 'win32/file/attributes'
   require 'win32/process'
-  require 'sys/admin'
 else
   require 'etc'
 end
@@ -98,14 +97,8 @@ module DBI
     #   # Find the first match for 'foo_user@some_database' under /usr/local
     #   DBI::DBRC.new('some_database', 'foo_usr', '/usr/local')
     #
-    def initialize(database, user = nil, dbrc_dir = nil)
+    def initialize(database, user = nil, dbrc_dir = Dir.home)
       if dbrc_dir.nil?
-        if WINDOWS
-          home = Sys::Admin.get_user(Process.uid, :localaccount => true).dir
-        else
-          home = Dir.home(Etc.getpwuid.name)
-        end
-
         # Default to the app data directory on Windows, or root on Unix, if
         # no home dir can be found.
         if home.nil?

--- a/spec/dbi_dbrc_spec.rb
+++ b/spec/dbi_dbrc_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe DBI::DBRC do
       end
     end
 
-    example "constructor raises an error if the permissions are invalid", :windows => false do
+    example "constructor raises an error if the permissions are invalid", :unix => true do
       File.chmod(0555, dbrc)
       expect{ described_class.new(db_foo, user1) }.to raise_error(described_class::Error)
     end

--- a/spec/dbi_dbrc_spec.rb
+++ b/spec/dbi_dbrc_spec.rb
@@ -49,13 +49,20 @@ RSpec.describe DBI::DBRC do
 
   context "windows", :windows => true do
     example "constructor raises an error unless the .dbrc file is hidden" do
-      File.unset_attr(plain, File::HIDDEN)
+      allow(FakeFS::File).to receive(:hidden?).and_return(false)
       expect{ described_class.new(db_foo, user1) }.to raise_error(described_class::Error)
     end
   end
 
   context "constructor" do
-    example "constructor raises an error if the permissions are invalid" do
+    before do
+      if File::ALT_SEPARATOR
+        allow(FakeFS::File).to receive(:hidden?).and_return(true)
+        allow(FakeFS::File).to receive(:encrypted?).and_return(false)
+      end
+    end
+
+    example "constructor raises an error if the permissions are invalid", :windows => false do
       File.chmod(0555, dbrc)
       expect{ described_class.new(db_foo, user1) }.to raise_error(described_class::Error)
     end
@@ -108,6 +115,7 @@ RSpec.describe DBI::DBRC do
       expect(dbrc.dsn).to be_nil
     end
   end
+=begin
 
   context "instance methods" do
     before do
@@ -233,4 +241,5 @@ RSpec.describe DBI::DBRC do
       expect(@dbrc).to respond_to(:max_reconn=)
     end
   end
+=end
 end

--- a/spec/dbi_dbrc_spec.rb
+++ b/spec/dbi_dbrc_spec.rb
@@ -115,10 +115,13 @@ RSpec.describe DBI::DBRC do
       expect(dbrc.dsn).to be_nil
     end
   end
-=begin
 
   context "instance methods" do
     before do
+      if File::ALT_SEPARATOR
+        allow(FakeFS::File).to receive(:hidden?).and_return(true)
+        allow(FakeFS::File).to receive(:encrypted?).and_return(false)
+      end
       @dbrc = DBI::DBRC.new(db_foo)
     end
 
@@ -241,5 +244,4 @@ RSpec.describe DBI::DBRC do
       expect(@dbrc).to respond_to(:max_reconn=)
     end
   end
-=end
 end

--- a/spec/dbi_dbrc_xml_spec.rb
+++ b/spec/dbi_dbrc_xml_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe DBI::DBRC::XML, :xml => true do
 
   before do
     allow(Dir).to receive(:home).and_return(home)
+
+    if File::ALT_SEPARATOR
+      allow(FakeFS::File).to receive(:hidden?).and_return(true)
+      allow(FakeFS::File).to receive(:encrypted?).and_return(false)
+    end
+
     FileUtils.mkdir_p(home)
     File.open(dbrc, 'w'){ |fh| fh.write(xml) }
     File.chmod(0600, dbrc)

--- a/spec/dbi_dbrc_yml_spec.rb
+++ b/spec/dbi_dbrc_yml_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe DBI::DBRC::YML, :yml => true do
 
   before do
     allow(Dir).to receive(:home).and_return(home)
+
+    if File::ALT_SEPARATOR
+      allow(FakeFS::File).to receive(:hidden?).and_return(true)
+      allow(FakeFS::File).to receive(:encrypted?).and_return(false)
+    end
+
     FileUtils.mkdir_p(home)
     File.open(dbrc, 'w'){ |fh| fh.write(yml) }
     File.chmod(0600, dbrc)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,4 +2,5 @@ require 'rspec'
 
 RSpec.configure do |config|
   config.filter_run_excluding(:windows) if RbConfig::CONFIG['host_os'] !~ /mswin|win32|dos|mingw|cygwin/i
+  config.filter_run_excluding(:unix) if RbConfig::CONFIG['host_os'] =~ /mswin|win32|dos|mingw|cygwin/i
 end


### PR DESCRIPTION
This updates the home handling which was originally written before the `Dir.home` method existed in core Ruby, and now just uses that method.

I also updated the specs to stub out some of the custom Windows methods from the `win32-file` gem because obviously those aren't defined by the FakeFS library.