### PR TITLE
Support GPG encrypted files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## 1.6.0 - 9-Jun-2021
+* Now supports gpg encrypted files, with a 4th optional parameter where you
+  can pass gpg options (usually a password, but whatever gpgme supports).
+* Added gpgme as a dependency.
+* Updated specs for MS Windows.
+* The "home" handling is now a bit simpler, as it was originally written
+  before that method existed in core Ruby.
+
 ## 1.5.0 - 12-Apr-2021
 * Switched from test-unit to rspec, with corresponding changes in the
   gemspec and Rakefile.

--- a/dbi-dbrc.gemspec
+++ b/dbi-dbrc.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'dbi-dbrc'
-  spec.version    = '1.5.0'
+  spec.version    = '1.6.0'
   spec.author     = 'Daniel Berger'
   spec.email      = 'djberg96@gmail.com'
   spec.license    = 'Apache-2.0'

--- a/dbi-dbrc.gemspec
+++ b/dbi-dbrc.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.test_files = Dir['test/test*.rb']
   spec.cert_chain = Dir['certs/*']
 
+  spec.add_dependency('gpgme', '~> 2.0')
+
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec', '~> 3.9')
   spec.add_development_dependency('fakefs', '~> 1.3')

--- a/lib/dbi/dbrc.rb
+++ b/lib/dbi/dbrc.rb
@@ -250,13 +250,14 @@ module DBI
   # public methods of this class are identical to DBRC.
   class DBRC::XML < DBRC
     require 'rexml/document' # Good enough for small files
-    include REXML
 
     private
 
     def parse_dbrc_config_file(file = @dbrc_file)
-      doc = Document.new(File.new(file))
+      doc = REXML::Document.new(File.new(file))
+
       fields = %w[user password driver interval timeout maximum_reconnects]
+
       doc.elements.each('/dbrc/database') do |element|
         next unless element.attributes['name'] == database
         next if @user && @user != element.elements['user'].text

--- a/lib/dbi/dbrc.rb
+++ b/lib/dbi/dbrc.rb
@@ -149,7 +149,7 @@ module DBI
           require 'stringio'
           crypto = GPGME::Crypto.new(gpg_options)
           stringio = crypto.decrypt(File.open(@dbrc_file))
-          parse_dbrc_config_file(stringio)
+          parse_dbrc_config_file(StringIO.new(stringio.read))
         else
           parse_dbrc_config_file
         end
@@ -174,7 +174,7 @@ module DBI
         end
       end.join(', ')
 
-      "#<#{self.class}:0x#{(object_id * 2).to_s(16)} " << str << '>'
+      "#<#{self.class}:0x#{(object_id * 2).to_s(16)} " + str + '>'
     end
 
     private
@@ -235,7 +235,7 @@ module DBI
           break
         end
       ensure
-        fh.close
+        fh.close if fh && fh.respond_to?(:close)
       end
 
       if @user

--- a/lib/dbi/dbrc.rb
+++ b/lib/dbi/dbrc.rb
@@ -254,7 +254,8 @@ module DBI
     private
 
     def parse_dbrc_config_file(file = @dbrc_file)
-      doc = REXML::Document.new(File.new(file))
+      file = file.is_a?(StringIO) ? file : File.new(file)
+      doc = REXML::Document.new(file)
 
       fields = %w[user password driver interval timeout maximum_reconnects]
 
@@ -282,7 +283,8 @@ module DBI
     private
 
     def parse_dbrc_config_file(file = @dbrc_file)
-      config = YAML.safe_load(File.open(file))
+      fh = file.is_a?(StringIO) ? file : File.open(file)
+      config = YAML.safe_load(fh)
 
       config.each do |hash|
         hash.each do |db, info|

--- a/lib/dbi/dbrc.rb
+++ b/lib/dbi/dbrc.rb
@@ -17,7 +17,7 @@ module DBI
     class Error < StandardError; end
 
     # The version of the dbi-dbrc library
-    VERSION = '1.5.0'
+    VERSION = '1.6.0'
 
     WINDOWS = File::ALT_SEPARATOR # :no-doc:
 

--- a/spec/dbi_dbrc_spec.rb
+++ b/spec/dbi_dbrc_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe DBI::DBRC do
   end
 
   example "version" do
-    expect(described_class::VERSION).to eq('1.5.0')
+    expect(described_class::VERSION).to eq('1.6.0')
     expect(described_class::VERSION).to be_frozen
   end
 


### PR DESCRIPTION
This PR adds encryption support using the gpgme library, which has also been added as a dependency. The constructor now supports an optional 4th parameter which is just gpg options - typically a password - that are forwarded to the gpgme library under the hood.

I also updated the version, and added changes for 1.6.0.