### PR TITLE
Split out subclasses into their own files

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -5,6 +5,8 @@
 * dbi-dbrc.gemspec
 * certs/djberg96_pub.pem
 * lib/dbi/dbrc.rb
+* lib/dbi/dbrc/xml.rb
+* lib/dbi/dbrc/yaml.rb
 * examples/plain/.dbrc
 * examples/plain/test.rb
 * examples/xml_examples/.dbrc

--- a/lib/dbi/dbrc.rb
+++ b/lib/dbi/dbrc.rb
@@ -245,62 +245,7 @@ module DBI
       end
     end
   end
-
-  # A subclass of DBRC designed to handle .dbrc files in XML format.  The
-  # public methods of this class are identical to DBRC.
-  class DBRC::XML < DBRC
-    require 'rexml/document' # Good enough for small files
-
-    private
-
-    def parse_dbrc_config_file(file = @dbrc_file)
-      file = file.is_a?(StringIO) ? file : File.new(file)
-      doc = REXML::Document.new(file)
-
-      fields = %w[user password driver interval timeout maximum_reconnects]
-
-      doc.elements.each('/dbrc/database') do |element|
-        next unless element.attributes['name'] == database
-        next if @user && @user != element.elements['user'].text
-
-        fields.each do |field|
-          val = element.elements[field]
-          send("#{field}=", val.text) unless val.nil?
-        end
-
-        break
-      end
-
-      raise Error, "No record found for #{@user}@#{@database}" unless @user && @database
-    end
-  end
-
-  # A subclass of DBRC designed to handle .dbrc files in YAML format. The
-  # public methods of this class are identical to DBRC.
-  class DBRC::YML < DBRC
-    require 'yaml'
-
-    private
-
-    def parse_dbrc_config_file(file = @dbrc_file)
-      fh = file.is_a?(StringIO) ? file : File.open(file)
-      config = YAML.safe_load(fh)
-
-      config.each do |hash|
-        hash.each do |db, info|
-          next unless db == @database
-          next if @user && @user != info['user']
-          @user = info['user']
-          @password = info['password']
-          @driver = info['driver']
-          @interval = info['interval']
-          @timeout = info['timeout']
-          @maximum_reconnects = info['maximum_reconnects']
-          break
-        end
-      end
-
-      raise Error, "No entry found for #{@user}@#{@database}" unless @user && @database
-    end
-  end
 end
+
+require_relative 'dbrc/xml'
+require_relative 'dbrc/yaml'

--- a/lib/dbi/dbrc/xml.rb
+++ b/lib/dbi/dbrc/xml.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative '../dbrc'
+
+# The DBI module serves as a namespace only.
+module DBI
+  # A subclass of DBRC designed to handle .dbrc files in XML format.  The
+  # public methods of this class are identical to DBRC.
+  class DBRC::XML < DBRC
+    require 'rexml/document' # Good enough for small files
+
+    private
+
+    def parse_dbrc_config_file(file = @dbrc_file)
+      file = file.is_a?(StringIO) ? file : File.new(file)
+      doc = REXML::Document.new(file)
+
+      fields = %w[user password driver interval timeout maximum_reconnects]
+
+      doc.elements.each('/dbrc/database') do |element|
+        next unless element.attributes['name'] == database
+        next if @user && @user != element.elements['user'].text
+
+        fields.each do |field|
+          val = element.elements[field]
+          send("#{field}=", val.text) unless val.nil?
+        end
+
+        break
+      end
+
+      raise Error, "No record found for #{@user}@#{@database}" unless @user && @database
+    end
+  end
+end

--- a/lib/dbi/dbrc/yaml.rb
+++ b/lib/dbi/dbrc/yaml.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative '../dbrc'
+
+# The DBI module serves as namespace only.
+module DBI
+  # A subclass of DBRC designed to handle .dbrc files in YAML format. The
+  # public methods of this class are identical to DBRC.
+  class DBRC::YML < DBRC
+    require 'yaml'
+
+    private
+
+    def parse_dbrc_config_file(file = @dbrc_file)
+      fh = file.is_a?(StringIO) ? file : File.open(file)
+      config = YAML.safe_load(fh)
+
+      config.each do |hash|
+        hash.each do |db, info|
+          next unless db == @database
+          next if @user && @user != info['user']
+          @user = info['user']
+          @password = info['password']
+          @driver = info['driver']
+          @interval = info['interval']
+          @timeout = info['timeout']
+          @maximum_reconnects = info['maximum_reconnects']
+          break
+        end
+      end
+
+      raise Error, "No entry found for #{@user}@#{@database}" unless @user && @database
+    end
+  end
+end

--- a/lib/dbi/dbrc/yaml.rb
+++ b/lib/dbi/dbrc/yaml.rb
@@ -13,7 +13,7 @@ module DBI
 
     def parse_dbrc_config_file(file = @dbrc_file)
       fh = file.is_a?(StringIO) ? file : File.open(file)
-      config = YAML.safe_load(fh)
+      config = ::YAML.safe_load(fh)
 
       config.each do |hash|
         hash.each do |db, info|
@@ -33,3 +33,5 @@ module DBI
     end
   end
 end
+
+DBI::DBRC::YAML = DBI::DBRC::YML # Alias


### PR DESCRIPTION
This splits the XML and YML subclasses into their own files.

It also adds a YAML alias, since I never remember.